### PR TITLE
Fixes issue #3 (not downloading functions on MacOS)

### DIFF
--- a/R/fct_download_file.R
+++ b/R/fct_download_file.R
@@ -27,7 +27,7 @@ my_download_file <- function(dl_link,
 
       # fix for issue 13: https://github.com/msperlin/GetDFPData/issues/13
       my.OS <- tolower(Sys.info()["sysname"])
-      if (my.OS == 'windows') {
+      if (my.OS %in% c('windows', 'darwin')) {
         utils::download.file(url = dl_link,
                              destfile = dest_file,
                              #method = 'wget',


### PR DESCRIPTION
Caro Marcelo, segue um PR pra tentar consertar a questão de não conseguir fazer download em MacOS. O ajuste é pequeno (1 linha apenas) e não deve influenciar usuários de Windows ou Linux. Na minha máquina, o build falhava no unit test e após esse ajuste, ele passou a funcionar normal. Uma descrição de como cheguei nessa proposta está no arquivo PDF anexo: [fix_wget_issue.pdf](https://github.com/msperlin/GetFREData/files/7440964/fix_wget_issue.pdf).
